### PR TITLE
LPS-170924 Lazy approach to simplify the CompanyThreadLocal logic and avoid errors and warnings while creating a company and accesing to the CompanyThreadLocal from a different thread. This also improves the performance since CompanyThreadLocal is much more used than Locale and TimeZone ThreadLocal and getDefaultUser method uses a local(but cluster sync) map to retrive the defaultUser.

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/util/LocaleThreadLocal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/LocaleThreadLocal.java
@@ -15,6 +15,10 @@
 package com.liferay.portal.kernel.util;
 
 import com.liferay.petra.lang.CentralizedThreadLocal;
+import com.liferay.portal.kernel.model.CompanyConstants;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 
 import java.util.Locale;
 
@@ -24,6 +28,17 @@ import java.util.Locale;
 public class LocaleThreadLocal {
 
 	public static Locale getDefaultLocale() {
+		if ((_defaultLocale.get() == null) &&
+			(CompanyThreadLocal.getCompanyId() != CompanyConstants.SYSTEM)) {
+
+			User defaultUser = UserLocalServiceUtil.fetchDefaultUser(
+				CompanyThreadLocal.getCompanyId());
+
+			if (defaultUser != null) {
+				_defaultLocale.set(defaultUser.getLocale());
+			}
+		}
+
 		return _defaultLocale.get();
 	}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/TimeZoneThreadLocal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/TimeZoneThreadLocal.java
@@ -15,6 +15,10 @@
 package com.liferay.portal.kernel.util;
 
 import com.liferay.petra.lang.CentralizedThreadLocal;
+import com.liferay.portal.kernel.model.CompanyConstants;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 
 import java.util.TimeZone;
 
@@ -24,6 +28,17 @@ import java.util.TimeZone;
 public class TimeZoneThreadLocal {
 
 	public static TimeZone getDefaultTimeZone() {
+		if ((_defaultTimeZone.get() == null) &&
+			(CompanyThreadLocal.getCompanyId() != CompanyConstants.SYSTEM)) {
+
+			User defaultUser = UserLocalServiceUtil.fetchDefaultUser(
+				CompanyThreadLocal.getCompanyId());
+
+			if (defaultUser != null) {
+				_defaultTimeZone.set(defaultUser.getTimeZone());
+			}
+		}
+
 		return _defaultTimeZone.get();
 	}
 


### PR DESCRIPTION
LPS-170924